### PR TITLE
[protobuf]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.protobuf?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # protobuf
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# protobuf
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Provides the `protoc` binary for compiling Protocol Buffer definitions; e.g.:
+
+```
+hab pkg exec core/protobuf protoc --help
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: 'bin/protoc'

--- a/controls/protobuf_exists.rb
+++ b/controls/protobuf_exists.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm protobuf exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'protobuf')
+
+control 'core-plans-protobuf-exists' do
+  impact 1.0
+  title 'Ensure protobuf exists'
+  desc '
+  Verify protobuf by ensuring bin/protoc exists'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: 'bin/protoc')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/protobuf_works.rb
+++ b/controls/protobuf_works.rb
@@ -1,0 +1,31 @@
+title 'Tests to confirm protobuf works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'protobuf')
+
+control 'core-plans-protobuf-works' do
+  impact 1.0
+  title 'Ensure protobuf works as expected'
+  desc '
+  Verify protobuf by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  command_relative_path = input('command_relative_path', value: 'bin/protoc')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /libprotoc #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: protobuf
+title: Habitat Core Plan protobuf
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan protobuf
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,45 @@
+$pkg_name="protobuf"
+$pkg_origin="core"
+$pkg_version="3.9.2"
+$pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
+$pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
+$pkg_upstream_url="https://developers.google.com/protocol-buffers/"
+$pkg_license=("BSD")
+$pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.zip"
+$pkg_shasum="c18c03b2beb14c8813e1ca4601bfef07755eccaf202c3d6a1187186fc30bb8a1"
+$pkg_deps=@(
+    "core/zlib"
+)
+$pkg_build_deps=@(
+    "core/visual-cpp-build-tools-2015",
+    "core/cmake"
+)
+$pkg_bin_dirs=@("bin")
+$pkg_lib_dirs=@("lib")
+$pkg_include_dirs=@("include")
+
+function Invoke-SetupEnvironment {
+    . "$(Get-HabPackagePath visual-cpp-build-tools-2015)\setenv.ps1"
+}
+
+function Invoke-Build {
+    Set-Location "$pkg_name-$pkg_version\cmake"
+
+    $zlib_libdir = "$(Get-HabPackagePath zlib)\lib\zlibwapi.lib"
+    $zlib_includedir = "$(Get-HabPackagePath zlib)\include"
+
+    mkdir build
+    Set-Location build
+    cmake -G "Visual Studio 14 2015 Win64" -T "v140" -DCMAKE_SYSTEM_VERSION="8.1" -DCMAKE_INSTALL_PREFIX=../../../../install -DZLIB_LIBRARY_RELEASE="${zlib_libdir}" -DZLIB_INCLUDE_DIR="${zlib_includedir}" ..
+    # We'll build the required parts here
+    msbuild /p:Configuration=Release /p:Platform=x64 "INSTALL.vcxproj"
+    if($LASTEXITCODE -ne 0) { Write-Error "msbuild failed!" }
+
+    .\extract_includes.bat
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake\build\Release\protoc.exe" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake\build\Release\*.lib" "$pkg_prefix\lib\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\cmake\build\include\*" "$pkg_prefix\include\" -Force
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,17 @@
+pkg_name=protobuf
+pkg_origin=core
+pkg_version=3.9.2
+pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
+pkg_upstream_url="https://developers.google.com/protocol-buffers/"
+pkg_license=('BSD')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.tar.gz"
+pkg_shasum=7c99ddfe0227cbf6a75d1e75b194e0db2f672d2d2ea88fb06bdc83fe0af4c06d
+pkg_deps=(
+  core/gcc
+  core/zlib
+)
+pkg_build_deps=(core/make)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} protoc --version | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Help command" {
+  run hab pkg exec ${TEST_PKG_IDENT} protoc --help
+  [ $status -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://861fbe4389f586652dedf0ad2f6960f3bc467e73c625f9ce905289e0a473dc7c --input-file /src/attributes.yml

Profile: Habitat Core Plan protobuf (protobuf)
Version: 0.1.0
Target:  docker://861fbe4389f586652dedf0ad2f6960f3bc467e73c625f9ce905289e0a473dc7c

  ✔  core-plans-protobuf-works: Ensure protobuf works as expected
     ✔  Command: `hab pkg path core/protobuf` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/protobuf` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/protobuf` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/protobuf/3.9.2/20200612142152/bin/protoc --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/protobuf/3.9.2/20200612142152/bin/protoc --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/protobuf/3.9.2/20200612142152/bin/protoc --version` stdout is expected to match /libprotoc 3.9.2/
     ✔  Command: `/hab/pkgs/core/protobuf/3.9.2/20200612142152/bin/protoc --version` stderr is expected to be empty
  ✔  core-plans-protobuf-exists: Ensure protobuf exists
     ✔  Command: `hab pkg path core/protobuf` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/protobuf` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/protobuf` stderr is expected to be empty
     ✔  File /hab/pkgs/core/protobuf/3.9.2/20200612142152/bin/protoc is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 11 successful, 0 failures, 0 skipped
+ set +x
[7][default:/src:0]# 
```