### PR TITLE
version bump from 3.15.6 to 3.19.0

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=protobuf
 pkg_origin=core
-pkg_version=3.15.6
+pkg_version=3.19.0
 pkg_description="Protocol buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data."
 pkg_upstream_url="https://developers.google.com/protocol-buffers/"
 pkg_license=('BSD')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_source="https://github.com/google/${pkg_name}/releases/download/v${pkg_version}/${pkg_name}-all-${pkg_version}.tar.gz"
-pkg_shasum=a96d66a29df73991ece4d82f04abf242d28f4cdacd7eb0ddf47f75a344a290af
+pkg_shasum=7b8d3ac3d6591ce9d25f90faba80da78d0ef620fda711702367f61a40ba98429
 pkg_deps=(
   core/gcc
   core/zlib


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4081
Signed-off-by: RaviDuddela <RaviShankar.Duddela@progress.com>